### PR TITLE
fix: preprocessor for review_date should use OrdinalEncoder

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -40,17 +40,13 @@ preprocessor = make_column_transformer(
         ]
     ),
     (
-        # pipeline-1
-        make_pipeline(
-            OrdinalEncoder(),
-            StandardScaler()
-        ),
+        OrdinalEncoder(),
         [
             'review_date'
         ]
     ),
     (
-        # pipeline-2
+        # pipeline-1
         make_pipeline(
             # convert ingredients to set
             FunctionTransformer(lambda df: [set(x[3:].split(',')) if isinstance(x, str) else set({}) for x in df['ingredients']]),
@@ -61,7 +57,7 @@ preprocessor = make_column_transformer(
         ]
     ),
     (
-        # pipeline-3
+        # pipeline-2
         make_pipeline(
             # drop the '%' from the strings
             FunctionTransformer(lambda df: df.apply(lambda x: x.str[:-1], axis=1)),

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -2,7 +2,7 @@ from sklearn.base import TransformerMixin
 from sklearn.compose import make_column_transformer
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.pipeline import make_pipeline
-from sklearn.preprocessing import FunctionTransformer, MultiLabelBinarizer, OneHotEncoder, StandardScaler
+from sklearn.preprocessing import FunctionTransformer, MultiLabelBinarizer, OneHotEncoder, OrdinalEncoder, StandardScaler
 
 
 # Ingredient list:
@@ -40,13 +40,17 @@ preprocessor = make_column_transformer(
         ]
     ),
     (
-        StandardScaler(),
+        # pipeline-1
+        make_pipeline(
+            OrdinalEncoder(),
+            StandardScaler()
+        ),
         [
             'review_date'
         ]
     ),
     (
-        # pipeline-1
+        # pipeline-2
         make_pipeline(
             # convert ingredients to set
             FunctionTransformer(lambda df: [set(x[3:].split(',')) if isinstance(x, str) else set({}) for x in df['ingredients']]),
@@ -57,7 +61,7 @@ preprocessor = make_column_transformer(
         ]
     ),
     (
-        # pipeline-2
+        # pipeline-3
         make_pipeline(
             # drop the '%' from the strings
             FunctionTransformer(lambda df: df.apply(lambda x: x.str[:-1], axis=1)),

--- a/src/preprocessor_demo.py
+++ b/src/preprocessor_demo.py
@@ -22,4 +22,4 @@ pipe = make_pipeline(
 # TODO: Replace with `RandomizedSearchCV`
 transformed = pipe.fit_transform(X_train)
 print(transformed.shape)
-print(pipe.named_steps['columntransformer'].named_transformers_['pipeline-1'].named_steps['mymultilabelbinarizer'].encoder.classes)
+print(pipe.named_steps['columntransformer'].named_transformers_['pipeline-2'].named_steps['mymultilabelbinarizer'].encoder.classes)

--- a/src/preprocessor_demo.py
+++ b/src/preprocessor_demo.py
@@ -22,4 +22,4 @@ pipe = make_pipeline(
 # TODO: Replace with `RandomizedSearchCV`
 transformed = pipe.fit_transform(X_train)
 print(transformed.shape)
-print(pipe.named_steps['columntransformer'].named_transformers_['pipeline-2'].named_steps['mymultilabelbinarizer'].encoder.classes)
+print(pipe.named_steps['columntransformer'].named_transformers_['pipeline-1'].named_steps['mymultilabelbinarizer'].encoder.classes)


### PR DESCRIPTION
This PR proposes an update to the preprocessor to use `OrdinalEncoder` for `review_date` instead.